### PR TITLE
Fixing HSM OAEP error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>agent</artifactId>    
     <name>Direct Project Security And Trust Agent</name>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.0.2</version>
     <description>Direct Project Security And Trust Agent</description>
     <inceptionYear>2010</inceptionYear>
     <url>https://github.com/DirectProjectJavaRI/agent</url> 

--- a/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectNamedJcaJceExtHelper.java
+++ b/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectNamedJcaJceExtHelper.java
@@ -4,6 +4,8 @@ import java.security.PrivateKey;
 
 import javax.crypto.SecretKey;
 
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
 import org.bouncycastle.operator.SymmetricKeyUnwrapper;
@@ -20,7 +22,19 @@ public class DirectNamedJcaJceExtHelper extends NamedJcaJceHelper implements Dir
 
     public JceAsymmetricKeyUnwrapper createAsymmetricUnwrapper(AlgorithmIdentifier keyEncryptionAlgorithm, PrivateKey keyEncryptionKey)
     {
-        return new DirectJceAsymmetricKeyUnwrapper(keyEncryptionAlgorithm, keyEncryptionKey).setProvider(providerName);
+    	final JceAsymmetricKeyUnwrapper retVal = new DirectJceAsymmetricKeyUnwrapper(keyEncryptionAlgorithm, keyEncryptionKey);
+    	retVal.setProvider(providerName);
+    	
+    	/*
+    	 * For a non-BC provider, we need to map the OAEP algorithm OID to a name.  Many HSMs do not recognized the algorithm OID and explicitly
+    	 * need the name.
+    	 */
+    	if (!StringUtils.isEmpty(providerName) && !providerName.equalsIgnoreCase("BC"))
+    	{
+    		retVal.setAlgorithmMapping(PKCSObjectIdentifiers.id_RSAES_OAEP, "RSA/ECB/OAEP");
+    	}
+    	
+        return retVal;
     }
     
     public JceKTSKeyUnwrapper createAsymmetricUnwrapper(AlgorithmIdentifier keyEncryptionAlgorithm, PrivateKey keyEncryptionKey, byte[] partyUInfo, byte[] partyVInfo)

--- a/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectNamedJcaJceExtHelper.java
+++ b/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectNamedJcaJceExtHelper.java
@@ -27,7 +27,7 @@ public class DirectNamedJcaJceExtHelper extends NamedJcaJceHelper implements Dir
     	
     	/*
     	 * For a non-BC provider, we need to map the OAEP algorithm OID to a name.  Many HSMs do not recognized the algorithm OID and explicitly
-    	 * need the name.
+    	 * need the name.  May need to get sophisticated in later versions to map names for specific HSMs. 
     	 */
     	if (!StringUtils.isEmpty(providerName) && !providerName.equalsIgnoreCase("BC"))
     	{

--- a/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectNamedJcaJceExtHelper.java
+++ b/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectNamedJcaJceExtHelper.java
@@ -31,7 +31,7 @@ public class DirectNamedJcaJceExtHelper extends NamedJcaJceHelper implements Dir
     	 */
     	if (!StringUtils.isEmpty(providerName) && !providerName.equalsIgnoreCase("BC"))
     	{
-    		retVal.setAlgorithmMapping(PKCSObjectIdentifiers.id_RSAES_OAEP, "RSA/ECB/OAEP");
+    		retVal.setAlgorithmMapping(PKCSObjectIdentifiers.id_RSAES_OAEP, "RSA/None/OAEPWithSHA1AndMGF1Padding");
     	}
     	
         return retVal;

--- a/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectProviderJcaJceExtHelper.java
+++ b/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectProviderJcaJceExtHelper.java
@@ -5,6 +5,8 @@ import java.security.Provider;
 
 import javax.crypto.SecretKey;
 
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
 import org.bouncycastle.operator.SymmetricKeyUnwrapper;
@@ -22,7 +24,19 @@ public class DirectProviderJcaJceExtHelper extends ProviderJcaJceHelper implemen
     
     public JceAsymmetricKeyUnwrapper createAsymmetricUnwrapper(AlgorithmIdentifier keyEncryptionAlgorithm, PrivateKey keyEncryptionKey)
     {
-        return new DirectJceAsymmetricKeyUnwrapper(keyEncryptionAlgorithm, keyEncryptionKey).setProvider(provider);
+    	final JceAsymmetricKeyUnwrapper retVal = new DirectJceAsymmetricKeyUnwrapper(keyEncryptionAlgorithm, keyEncryptionKey);
+    	retVal.setProvider(provider);
+    	
+    	/*
+    	 * For a non-BC provider, we need to map the OAEP algorithm OID to a name.  Many HSMs do not recognized the algorithm OID and explicitly
+    	 * need the name.
+    	 */
+    	if (provider != null && !StringUtils.isEmpty(provider.getName()) && !provider.getName().equalsIgnoreCase("BC"))
+    	{
+    		retVal.setAlgorithmMapping(PKCSObjectIdentifiers.id_RSAES_OAEP, "RSA/ECB/OAEP");
+    	}    	
+    	
+        return retVal;
     }
     
     public JceKTSKeyUnwrapper createAsymmetricUnwrapper(AlgorithmIdentifier keyEncryptionAlgorithm, PrivateKey keyEncryptionKey, byte[] partyUInfo, byte[] partyVInfo)

--- a/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectProviderJcaJceExtHelper.java
+++ b/src/main/java/org/nhindirect/stagent/cryptography/bc/DirectProviderJcaJceExtHelper.java
@@ -29,11 +29,11 @@ public class DirectProviderJcaJceExtHelper extends ProviderJcaJceHelper implemen
     	
     	/*
     	 * For a non-BC provider, we need to map the OAEP algorithm OID to a name.  Many HSMs do not recognized the algorithm OID and explicitly
-    	 * need the name.
+    	 * need the name.  May need to get sophisticated in later versions to map names for specific HSMs. 
     	 */
     	if (provider != null && !StringUtils.isEmpty(provider.getName()) && !provider.getName().equalsIgnoreCase("BC"))
     	{
-    		retVal.setAlgorithmMapping(PKCSObjectIdentifiers.id_RSAES_OAEP, "RSA/ECB/OAEP");
+    		retVal.setAlgorithmMapping(PKCSObjectIdentifiers.id_RSAES_OAEP, "RSA/None/OAEPWithSHA1AndMGF1Padding");
     	}    	
     	
         return retVal;


### PR DESCRIPTION
These changes fix an error when decrypting with an HSM where the message is encrypted with OAEP padding.  This addresses issue #7 